### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ baciphacs
 
 Bar charts in pure HTML and CSS.
 
-[![PyPi version](https://pypip.in/v/baciphacs/badge.png)](https://crate.io/packages/baciphacs) 
-[![PyPi downloads](https://pypip.in/d/baciphacs/badge.png)](https://crate.io/packages/baciphacs)
+[![PyPi version](https://img.shields.io/pypi/v/baciphacs.svg)](https://crate.io/packages/baciphacs) 
+[![PyPi downloads](https://img.shields.io/pypi/dm/baciphacs.svg)](https://crate.io/packages/baciphacs)
 
 This library is designed for the kind of (desesperate) situation where
 you want to display bar charts but with the constraint that your HTML


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20baciphacs))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `baciphacs`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.